### PR TITLE
Deps: Upgrade `@alma-career/stylelint-config`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "vanilla-cookieconsent": "3.1.0"
   },
   "devDependencies": {
-    "@almacareer/stylelint-config": "9.0.1",
+    "@almacareer/stylelint-config": "9.1.0",
     "@babel/core": "7.26.9",
     "@babel/preset-env": "7.26.9",
     "@commitlint/cli": "19.7.1",

--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
       "matchPackageNames": ["*"]
     },
     {
-      "groupName": "Froze eslint on ^8",
+      "groupName": "Freeze eslint on ^8",
       "description": "Lock eslint on ^8 until @lmc-eu/eslint-config-base is compatible with eslint 9",
       "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
@@ -53,13 +53,6 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["conventional-changelog-cli"],
       "allowedVersions": "^3"
-    },
-    {
-      "groupName": "Temporarily froze stylelint config on 9.0.*",
-      "description": "@almacareer/stylelint-config in version 9.1+ is failing",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@almacareer/stylelint-config"],
-      "allowedVersions": "<9.1.0"
     }
   ]
 }

--- a/src/scss/style/_buttons.scss
+++ b/src/scss/style/_buttons.scss
@@ -1,5 +1,6 @@
 // 1. Any order is correct for us, but call the typography mixin last to prevent Sass deprecation warning.
-// @see https://sass-lang.com/d/mixed-decls
+//    @see https://sass-lang.com/d/mixed-decls
+// 2. Alma's stylelint-config is not yet ready to force blockless mixin calls to come after declarations (see 1.).
 
 @use '@tokens' as tokens;
 @use '../tools/typography';
@@ -11,5 +12,6 @@
     padding-inline: calc(#{tokens.$space-900} - #{tokens.$border-width-100});
     padding-block: calc(#{tokens.$space-500} - #{tokens.$border-width-100});
 
+    // stylelint-disable-next-line order/order -- 2.
     @include typography.generate(tokens.$body-small-semibold); // 1.
 }

--- a/src/scss/style/_preferences-modal.scss
+++ b/src/scss/style/_preferences-modal.scss
@@ -1,6 +1,7 @@
 // 1. Revert inline overrides of the original library 🤦🏻‍♂️.
 // 2. Any order is correct for us, but call the typography mixin last to prevent Sass deprecation warning.
-// @see https://sass-lang.com/d/mixed-decls
+//    @see https://sass-lang.com/d/mixed-decls
+// 3. Alma's stylelint-config is not yet ready to force blockless mixin calls to come after declarations (see 2.).
 
 @use '@tokens' as tokens;
 @use '../tools/typography';
@@ -24,6 +25,7 @@
 #cc-main .pm__title {
     margin-right: tokens.$space-500;
 
+    // stylelint-disable-next-line order/order -- 3.
     @include typography.generate(tokens.$heading-small-bold); // 2.
 }
 

--- a/src/scss/tools/_themes.scss
+++ b/src/scss/tools/_themes.scss
@@ -14,14 +14,13 @@
     @each $theme-name, $theme-token-types in $themes {
         $selector: if($is-default-theme, ':root, .#{$theme-name}', '.#{$theme-name}');
         $theme-mixins: map.get($theme-token-types, mixins);
+        $is-default-theme: false;
 
         #{$selector} {
             @each $theme-mixin-name, $theme-mixin in $theme-mixins {
                 @include meta.apply($theme-mixin);
             }
         }
-
-        $is-default-theme: false;
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@almacareer/stylelint-config@9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@almacareer/stylelint-config/-/stylelint-config-9.0.1.tgz#773e680834dc8af83b06f929e437228a13bdfe59"
-  integrity sha512-D7/oTdZU6lPW0CuxXgJu1sVU+JQsdn/3EKsvIztZq4kBSvhYOqumIDy+DMi1jBFC2LCjj8gKTjhe3w3Jsuslrw==
+"@almacareer/stylelint-config@9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@almacareer/stylelint-config/-/stylelint-config-9.1.0.tgz#11cfe6256d72f5ec73739fea77ddf67b32d42d15"
+  integrity sha512-nKEeQyTyWI3lqLGH1SHTlRbKDr38gtxiIrr5fKShEGc0yzzH8UL25Is42Z/gEwN36Vs5L/bRSva89W9LLekkMQ==
   dependencies:
     postcss-scss "^4.0.3"
     stylelint-config-standard-scss "^13.0.0"


### PR DESCRIPTION
Upgrade our Stylelint config to the latest version.

However, recent Sass deprecation of mixed declarations collides with our Stylelint config order rule. Let's step back to Sass and fix it in our Stylelint config later.