### PR TITLE
Docs: Add language to cookie contents example

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -108,6 +108,7 @@ you must update your server-side code to reflect this.
     "functionality": [],
     "personalization": []
   },
+  "languageCode": "en",
   "lastConsentTimestamp": "2024-12-12T12:12:12.333Z",
   "expirationTime": 1764690394793
 }


### PR DESCRIPTION
This is newly available since vanilla-cookieconsent 3.1.0.